### PR TITLE
Create Next.js portfolio skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# portfolio
-Portfolio Nicolas Lopez de lerma Lopez (MaquinaTech)
+# Nicolas Lopez Portfolio
+
+This project showcases my work experience, skills and education using **Next.js**, **Tailwind CSS** and **Framer Motion** for smooth animations and a clean user interface.
+
+## Scripts
+
+- `npm run dev` - Start the development server
+- `npm run build` - Build the application for production
+- `npm start` - Start the production server
+
+## Structure
+
+- `pages/` - Application pages
+- `components/` - Reusable components such as navigation and experience cards
+- `styles/` - Global styles powered by Tailwind CSS
+
+Install dependencies with `npm install` and then run any of the scripts above.

--- a/components/Experience.js
+++ b/components/Experience.js
@@ -1,0 +1,16 @@
+import { motion } from 'framer-motion'
+
+export default function Experience({ title, company, period, children }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+      className="bg-white p-4 rounded shadow mb-4"
+    >
+      <h3 className="text-xl font-semibold">{title}</h3>
+      <p className="italic text-sm text-gray-500">{company} | {period}</p>
+      <div className="mt-2 text-gray-700">{children}</div>
+    </motion.div>
+  )
+}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+import NavBar from './NavBar'
+
+export default function Layout({ children }) {
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <Head>
+        <title>Nicolas Lopez - Portfolio</title>
+        <meta name="description" content="Portfolio of Nicolas Lopez de Lerma" />
+      </Head>
+      <NavBar />
+      <main className="flex-grow container mx-auto px-4 py-8">{children}</main>
+      <footer className="text-center py-4 text-gray-500">&copy; {new Date().getFullYear()} Nicolas Lopez</footer>
+    </div>
+  )
+}

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+
+export default function NavBar() {
+  return (
+    <nav className="bg-white shadow mb-8">
+      <div className="container mx-auto px-4 py-3 flex justify-between items-center">
+        <Link href="/" className="font-bold text-xl">Nicolas</Link>
+        <motion.ul className="flex space-x-4" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+          <li>
+            <Link href="/" className="hover:text-blue-600">Home</Link>
+          </li>
+          <li>
+            <Link href="/about" className="hover:text-blue-600">About</Link>
+          </li>
+        </motion.ul>
+      </div>
+    </nav>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "framer-motion": "10.18.1"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.31",
+    "tailwindcss": "3.4.4"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import '@/styles/globals.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,0 +1,23 @@
+import Layout from '@/components/Layout'
+import { motion } from 'framer-motion'
+
+export default function About() {
+  return (
+    <Layout>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5 }}
+        className="prose mx-auto"
+      >
+        <h1>About Me</h1>
+        <p>
+          I am a proactive developer who excels both in teams and working autonomously. My strong decision-making skills and attention to detail allow me to deliver high-quality solutions across the entire stack.
+        </p>
+        <p>
+          Fluent in Spanish, English, and Portuguese, I bring a global perspective to every project. My experience ranges from database design to creating remarkable user experiences, always following Clean Code principles and modern best practices.
+        </p>
+      </motion.div>
+    </Layout>
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,70 @@
+import Layout from '@/components/Layout'
+import Experience from '@/components/Experience'
+import { motion } from 'framer-motion'
+
+export default function Home() {
+  return (
+    <Layout>
+      <section className="text-center mb-8">
+        <motion.h1
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.6 }}
+          className="text-4xl font-bold mb-2"
+        >
+          Nicolas Lopez de Lerma Lopez
+        </motion.h1>
+        <p className="text-gray-600 max-w-2xl mx-auto">
+          Full Stack Developer &amp; Technology Leader with extensive experience in mobile and web development. I create scalable solutions with a keen eye for detail and user experience.
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-4">Work Experience</h2>
+        <Experience title="CTO" company="Laurel Gaming" period="10-2024 - Present">
+          <ul className="list-disc list-inside space-y-1">
+            <li>Led mobile app development using React Native with monorepo architecture.</li>
+            <li>Implemented predictive notifications and gamification to improve engagement.</li>
+            <li>Oversaw admin panel and landing built with Next.js.</li>
+          </ul>
+        </Experience>
+        <Experience title="Full Stack Developer - Team Lead" company="Fundecyt PCTEX" period="04-2024 - Present">
+          <ul className="list-disc list-inside space-y-1">
+            <li>Developed employee management tools with Laravel and React Native.</li>
+            <li>Introduced REST APIs and clean code practices to improve productivity.</li>
+          </ul>
+        </Experience>
+        <Experience title="Full Stack Developer" company="Grupo Blendio" period="09-2023 - 10-2024">
+          <ul className="list-disc list-inside space-y-1">
+            <li>Created management tools and mobile apps with Laravel and React Native.</li>
+            <li>Implemented OTA updates and secure API Gateway for 600+ employees.</li>
+          </ul>
+        </Experience>
+        <Experience title="Full Stack Developer" company="WealtyApp" period="01-2023 - 06-2023">
+          <ul className="list-disc list-inside space-y-1">
+            <li>Led platform development with Next.js and React Native.</li>
+            <li>Integrated payment systems and automated deployments.</li>
+          </ul>
+        </Experience>
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4">Education</h2>
+        <div className="space-y-4">
+          <div className="bg-white p-4 rounded shadow">
+            <h3 className="font-semibold">Universidad de Extremadura - Computer Software Engineering</h3>
+            <p className="text-sm text-gray-500">Research project BigData I3Lab, focus on Python, Java, UX, databases and algorithms.</p>
+          </div>
+          <div className="bg-white p-4 rounded shadow">
+            <h3 className="font-semibold">Autodidact</h3>
+            <p className="text-sm text-gray-500">Self-learning various languages and frameworks including Laravel, Next.js, React Native and more.</p>
+          </div>
+          <div className="bg-white p-4 rounded shadow">
+            <h3 className="font-semibold">I.E.S Maestro Domingo Cáceres - Bachelor of Science</h3>
+            <p className="text-sm text-gray-500">Specialization in Mathematics and Physics.</p>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  )
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- set up Next.js project structure with Tailwind CSS and Framer Motion
- add reusable layout, navbar and experience components
- implement pages showing work experience and education
- update README with usage instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68866721c0988330821727754261ab02