### PR TITLE
Fix Next.js lockfile integrity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,7 +1544,7 @@
     "node_modules/next": {
       "version": "15.4.6",
       "resolved": "https://registry.npmjs.org/next/-/next-15.4.6.tgz",
-      "integrity": "sha512-kNcubvJjOL9yUOfwtZF3HfDhuhp+kVD+FM2A6Tyua1eI/xfmY4r/8ZS913MMz+oWKDlbps/dQOWdDricuIkXLw==",
+      "integrity": "sha512-us++E/Q80/8+UekzB3SAGs71AlLDsadpFMXVNM/uQ0BMwsh9m3mr0UNQIfjKed8vpWXsASe+Qifrnu1oLIcKEQ==",
       "license": "MIT",
       "dependencies": {
         "@next/env": "15.4.6",


### PR DESCRIPTION
### Motivation
- Prevent `npm install` integrity checksum failures caused by a mismatched Next.js tarball checksum recorded in `package-lock.json`.

### Description
- Update the `integrity` field for the `node_modules/next` entry in `package-lock.json` to the correct sha512 checksum.

### Testing
- No automated tests were run because this is a lockfile-only change and does not modify source code or runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987bdde5e80833091b69b974053a333)